### PR TITLE
feat: add theme provider and toggle button for dark/light mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "embla-carousel-react": "^8.2.1",
         "lucide-react": "^0.438.0",
         "next": "14.2.7",
+        "next-themes": "^0.4.3",
         "react": "^18",
         "react-dom": "^18",
         "react-hook-form": "^7.53.0",
@@ -6177,6 +6178,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.3.tgz",
+      "integrity": "sha512-nG84VPkTdUHR2YeD89YchvV4I9RbiMAql3GiLEQlPvq1ioaqPaIReK+yMRdg/zgiXws620qS1rU30TiWmmG9lA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "embla-carousel-react": "^8.2.1",
     "lucide-react": "^0.438.0",
     "next": "14.2.7",
+    "next-themes": "^0.4.3",
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.53.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Footer } from '@/components/footer/'
 import { Navbar } from '@/components/navbar/'
+import { ThemeProvider } from '@/components/providers/theme-provider'
 import { Red_Hat_Display as RedHatDisplay } from 'next/font/google'
 import './globals.css'
 import { siteConfig } from '@/config'
@@ -47,13 +48,24 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="pt-BR" className={redHatDisplay.className}>
+    <html
+      lang="pt-BR"
+      className={redHatDisplay.className}
+      suppressHydrationWarning
+    >
       <body className="relative h-full antialiased">
-        <div className="flex min-h-screen w-full flex-col">
-          <Navbar />
-          <main>{children}</main>
-          <Footer />
-        </div>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="light"
+          enableSystem
+          disableTransitionOnChange
+        >
+          <div className="flex min-h-screen w-full flex-col">
+            <Navbar />
+            <main>{children}</main>
+            <Footer />
+          </div>
+        </ThemeProvider>
       </body>
     </html>
   )

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -1,9 +1,10 @@
-import { Button, buttonVariants } from '@/components/shadcn-ui/button'
+import { buttonVariants } from '@/components/shadcn-ui/button'
 import { PAGES } from '@/config'
-import { Github, MoonStar } from 'lucide-react'
+import { Github } from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { MobileNav } from './mobile-nav'
+import { ThemeModeButton } from '../shadcn-ui/theme-mode'
 
 export function Navbar() {
   return (
@@ -32,9 +33,7 @@ export function Navbar() {
           <div className="h-4 w-0.5 bg-border"></div>
 
           <div className="space-x-3 text-muted-foreground">
-            <Button variant="ghost" size="icon">
-              <MoonStar className="size-5" />
-            </Button>
+            <ThemeModeButton />
 
             <Link
               href="https://github.com/linkjrcastanhal/linkjr"

--- a/src/components/navbar/mobile-nav.tsx
+++ b/src/components/navbar/mobile-nav.tsx
@@ -3,9 +3,10 @@
 import { Button, buttonVariants } from '@/components/shadcn-ui/button'
 import { Sheet, SheetContent, SheetTrigger } from '@/components/shadcn-ui/sheet'
 import { PAGES } from '@/config'
-import { Github, Menu, MoonStar } from 'lucide-react'
+import { Github, Menu } from 'lucide-react'
 import Link from 'next/link'
 import { useState } from 'react'
+import { ThemeModeButton } from '../shadcn-ui/theme-mode'
 
 export function MobileNav() {
   const [open, setOpen] = useState(false)
@@ -31,9 +32,7 @@ export function MobileNav() {
           </nav>
 
           <div className="mt-6 space-x-3 text-muted-foreground">
-            <Button variant="outline" size="icon">
-              <MoonStar className="size-5" />
-            </Button>
+            <ThemeModeButton />
 
             <Link
               href="https://github.com/linkjrcastanhal/linkjr"

--- a/src/components/providers/theme-provider.tsx
+++ b/src/components/providers/theme-provider.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import * as React from 'react'
+import { ThemeProvider as NextThemesProvider } from 'next-themes'
+
+export function ThemeProvider({
+  children,
+  ...props
+}: React.ComponentProps<typeof NextThemesProvider>) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+}

--- a/src/components/shadcn-ui/theme-mode.tsx
+++ b/src/components/shadcn-ui/theme-mode.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { useTheme } from "next-themes"
+import { Button } from '@/components/shadcn-ui/button'
+import { MoonStar, Sun } from 'lucide-react'
+import { useEffect, useState } from "react"
+
+export function ThemeModeButton() {
+  const { theme, setTheme } = useTheme()
+  const [isMounted, setIsMounted] = useState(false)
+
+  useEffect(() => {
+    setIsMounted(true)
+  }, [])
+
+  if (!isMounted) {
+    return null
+  }
+
+  const isLightTheme = theme === 'light'
+
+  const handleThemeToggle = () => {
+    setTheme(isLightTheme ? 'dark' : 'light')
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={handleThemeToggle}
+      aria-label={`Mudar para o modo ${isLightTheme ? 'escuro' : 'claro'}`}
+    >
+      {isLightTheme ? <MoonStar className="size-5" /> : <Sun className="size-5" />}
+    </Button>
+  )
+}


### PR DESCRIPTION
Como um visitante do site, quero alternar entre os modos claro e escuro, para ajustar a aparência da interface às minhas preferências visuais e às condições de iluminação.

**Critérios importantes:**

1. O footer deve conter:
   * Deve haver um botão ou ícone visível na interface para alternar entre os modos claro e escuro.
   * O tema deve ser atualizado instantaneamente ao clicar no botão.

<sub><a href="https://huly.app/guest/linkjr?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzRlNzc4MWQyZWY0Y2JjYzQ2ZGEwMDIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctbGlua2pyY2FzdGFuLWxpbmtqci02NzBiNDcyNS0wMzVjZTM3MDEzLTYxYTg4NSJ9.3MuBFeUiPxMGHW0ASaNpswvwBcgK5hMbR6539mk2dxc">Huly&reg;: <b>LNK-15</b></a></sub>